### PR TITLE
fix(#15): center longtable with balanced margins

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -27,9 +27,10 @@ Kong Style)}
 \renewcommand{\arraystretch}{1.8}
 \setlength{\tabcolsep}{8pt}
 
-\noindent\hspace*{\fill}
+\setlength\LTleft{\fill}
+\setlength\LTright{\fill}
 \rowcolors{1}{blue!10}{cyan!10}
-\begin{longtable}{|p{2.0cm}|p{6.95cm}|p{6.95cm}|}
+\begin{longtable}{|p{2.0cm}|p{6.0cm}|p{6.0cm}|}
   \hline
   \textbf{Day} & \textbf{Brunch (10--11am)} & \textbf{Dinner (5--6pm)} \\
   \hline
@@ -63,8 +64,7 @@ Kong Style)}
   Steamed milk pudding} &
   {\raggedright Creamed corn and shredded chicken thick soup\\
   Soft-cooked choy sum over rice} \\
-  \hline
+\hline
 \end{longtable}
-\hspace*{\fill}
 
 \end{document}


### PR DESCRIPTION
## Summary
- Center the `longtable` in `main.tex` using `\LTleft` and `\LTright` set to `\fill`.
- Reduce the two content column widths so the table fits within the text block and centers evenly.

## Validation
- Verified the table now appears centered with equal left and right margins in the compiled output.

Closes #15
